### PR TITLE
Pointer casting to allow compilling

### DIFF
--- a/src/UVCCameraControl.m
+++ b/src/UVCCameraControl.m
@@ -370,7 +370,7 @@ const uvc_controls_t uvc_controls = {
 }
 
 - (uvc_controls_t *) getControls{
-    return &uvc_controls;
+    return (uvc_controls_t *)&uvc_controls;
 }
 
 


### PR DESCRIPTION
I could not compile in Xcode 4.4.1 on Lion as it keeps complaining that on these lines

```
- (uvc_controls_t *) getControls{
    return &uvc_controls;
}
```

UVCCameraControl.m:373:12: Cannot initialize return object of type 'uvc_controls_t *' with an rvalue of type 'const uvc_controls_t *'

So, all I did was to cast the pointer there, and now it works fine

```
- (uvc_controls_t *) getControls{
    return (uvc_controls_t *)&uvc_controls;
}
```
