### PR TITLE
Set return type of getBrightness() to be float, not bool

### DIFF
--- a/src/ofxUVC.h
+++ b/src/ofxUVC.h
@@ -1,4 +1,3 @@
-
 #pragma once 
 
 
@@ -55,7 +54,7 @@ class ofxUVC {
     void setGain(float value);
     float getGain();
     void setBrightness(float value);
-    bool getBrightness();
+    float getBrightness();
     void setContrast(float value);
     float getContrast();
     void setSaturation(float value);

--- a/src/ofxUVC.mm
+++ b/src/ofxUVC.mm
@@ -80,7 +80,7 @@ void ofxUVC::setBrightness(float value){
     [cameraControl setBrightness:value];
 }
 
-bool ofxUVC::getBrightness(){
+float ofxUVC::getBrightness(){
     return [cameraControl getBrightness];
 }
 


### PR DESCRIPTION
Just a minor fix.  Sorry these are in two commits (you can flatten it down when you merge) -- it's because I tried using the "Edit" feature in GitHub, doing it directly on the website…

Thanks,
Glen.
