### PR TITLE
Logitech c615

### DIFF
--- a/example-ofxUVC/bin/data/camera_settings.yml
+++ b/example-ofxUVC/bin/data/camera_settings.yml
@@ -1,4 +1,4 @@
-cameraToUse: 0
+cameraToUse: 7
 cameras:
 - name: Microsoft LifeCam HD-5000
   vendorId: 0x45e
@@ -45,3 +45,10 @@ cameras:
   interfaceNum: 0x00
   width: 640
   height: 480
+- name: Logitech c615
+  vendorId : 0x46d
+  productId: 0x82c
+  interfaceNum: 0x02
+  # Video Capture (4:3 SD) 320 x 240, 640 x 480, Video Capture (16:9 W) 360P, 480P, 720P, 1080P
+  width: 480
+  height: 360

--- a/src/ofxUVC.mm
+++ b/src/ofxUVC.mm
@@ -128,8 +128,8 @@ vector<ofxUVCControl> ofxUVC::getCameraControls(){
     result.push_back(exposure);
     
 	ofxUVCControl absoluteFocus;
-    absoluteFocus.name = "absoluteFocus";
-    absoluteFocus.status = [cameraControl getInfoForControl:&[cameraControl getControls]->absoluteFocus];
+    absoluteFocus.status = [cameraControl getInfoForControl:&[cameraControl getControls]->focus];
+    //absoluteFocus.status = [cameraControl getInfoForControl:&[cameraControl getControls]->absoluteFocus];
     result.push_back(absoluteFocus);
 
 	ofxUVCControl focus;


### PR DESCRIPTION
I have a Logitech c615 working with the addon on OSX 10.9.
Had to make a change on absoluteFocus initialisation to make manual focus work using focus params, not sure if thats correct but works for me and I saw a similar change on absoluteFocus getters/setters.
